### PR TITLE
No-Jira: relax hobo_support version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     large_text_field (0.3.0)
-      hobo_support (~> 2.2)
+      hobo_support (~> 2.0)
       protected_attributes (~> 1.1)
       rails (~> 4.2)
 

--- a/large_text_field.gemspec
+++ b/large_text_field.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "protected_attributes", "~> 1.1"
   s.add_dependency "rails",        "~> 4.2"
-  s.add_dependency "hobo_support", "~> 2.2"
+  s.add_dependency "hobo_support", "~> 2.0"
 end


### PR DESCRIPTION
These changes needed to unblock downstream consumers. 

This gem doesn't care what version of hobo_support is available, so long as version >= 2.0.0 is available.

When this work is approved, I'll release a new patch version straight off of master.