### PR TITLE
no-jira: support rails 6 migrations

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -10,5 +10,5 @@ appraise 'rails-5' do
 end
 
 appraise 'rails-6' do
-  gem 'rails', '~> 6.0'
+  gem 'rails', '~> 6.0', '< 6.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ## [1.0.1] - 2021-02-16
 ### Fixed
 - Fixed migration to work with Rails 6 (by adding [4.2] suffix).
+- Set rails version to < 6.1 since that moved some files around and broke requires.
 
 ## [1.0.0] - 2020-05-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2021-02-16
+### Fixed
+- Fixed migration to work with Rails 6 (by adding [4.2] suffix).
+
 ## [1.0.0] - 2020-05-15
 ### Added
 - Added support for rails 5 and 6.
@@ -17,5 +21,6 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Replaced dependence on hobo_support with invoca_utils
 - Make invoca_utils a declared dependency. (It always was, it just wasn't declared)
 
-[1.0.0]: https://github.com/Invoca/large_text_field/compary/v0.3.2...v1.0.0
+[1.0.1]: https://github.com/Invoca/large_text_field/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/Invoca/large_text_field/compare/v0.3.2...v1.0.0
 [0.3.2]: https://github.com/Invoca/large_text_field/compare/v0.3.1...v0.3.2

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'appraisal'
 gem 'minitest', '~> 5.1'
 gem 'minitest-reporters'
 gem 'pry'
+gem 'rails',     '< 6.1'
 gem 'rr',        '~> 1.1'
 gem 'rubocop', require: false
 gem 'shoulda',   '~> 3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ DEPENDENCIES
   minitest (~> 5.1)
   minitest-reporters
   pry
+  rails (< 6.1)
   rr (~> 1.1)
   rubocop
   shoulda (~> 3.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    large_text_field (1.0.0)
+    large_text_field (1.0.1)
       invoca-utils (~> 0.3)
       rails (>= 4.2, < 7)
 
@@ -58,7 +58,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    invoca-utils (0.3.0)
+    invoca-utils (0.4.1)
     jaro_winkler (1.5.4)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -133,10 +133,10 @@ GEM
     shoulda-context (1.2.2)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    sprockets (4.0.0)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -167,4 +167,4 @@ DEPENDENCIES
   test-unit (~> 3.3)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/db/migrate/20110217210640_add_large_text_fields.rb
+++ b/db/migrate/20110217210640_add_large_text_fields.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class AddLargeTextFields < ActiveRecord::Migration
-
+class AddLargeTextFields < (Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
   def self.up
     create_table :large_text_fields do |t|
       t.string  :field_name, null: false

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -7,12 +7,12 @@ gem "appraisal"
 gem "minitest", "~> 5.1"
 gem "minitest-reporters"
 gem "pry"
+gem "rails", "~> 4.2"
 gem "rr", "~> 1.1"
 gem "rubocop", require: false
 gem "shoulda", "~> 3.5"
 gem "shoulda-matchers", "~> 2.0"
 gem "sqlite3"
 gem "test-unit", "~> 3.3"
-gem "rails", "~> 4.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -7,12 +7,12 @@ gem "appraisal"
 gem "minitest", "~> 5.1"
 gem "minitest-reporters"
 gem "pry"
+gem "rails", "~> 5.2"
 gem "rr", "~> 1.1"
 gem "rubocop", require: false
 gem "shoulda", "~> 3.5"
 gem "shoulda-matchers", "~> 3.0"
 gem "sqlite3"
 gem "test-unit", "~> 3.3"
-gem "rails", "~> 5.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -7,12 +7,12 @@ gem "appraisal"
 gem "minitest", "~> 5.1"
 gem "minitest-reporters"
 gem "pry"
+gem "rails", "~> 6.0", "< 6.1"
 gem "rr", "~> 1.1"
 gem "rubocop", require: false
 gem "shoulda", "~> 3.5"
 gem "shoulda-matchers", "~> 2.0"
 gem "sqlite3"
 gem "test-unit", "~> 3.3"
-gem "rails", "~> 6.0"
 
 gemspec path: "../"

--- a/lib/large_text_field/version.rb
+++ b/lib/large_text_field/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LargeTextField
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
## [1.0.1] - 2021-02-16
### Fixed
- Fixed migration to work with Rails 6 (by adding [4.2] suffix).
- Set rails version to < 6.1 since that moved some files around and broke requires.